### PR TITLE
Fix build with protobuf library

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
 # node-cld3
+
+Wrapper around the cld3 library. (WIP)
+
+1. Clone this repository
+2. Ensure you are using Node.js 18
+3. Run `npm install`
+4. Test with `node test/index.js`

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       "dependencies": {
         "bindings": "^1.5.0",
         "cmake-js": "^7.2.1",
-        "node-addon-api": "^6.0.0"
+        "node-addon-api": "^6.1.0"
       }
     },
     "node_modules/ansi-regex": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,6 @@
   "dependencies": {
     "bindings": "^1.5.0",
     "cmake-js": "^7.2.1",
-    "node-addon-api": "^6.0.0"
+    "node-addon-api": "^6.1.0"
   }
 }

--- a/scripts/setup.js
+++ b/scripts/setup.js
@@ -9,7 +9,7 @@ const root = path.join(__dirname, '..');
 const cld3Path = path.join(root, 'cld3');
 
 execSync('rm -rf cld3', { cwd: root });
-execSync('git clone https://github.com/google/cld3.git', { cwd: root });
+execSync('git clone https://github.com/Aschen/cld3.git', { cwd: root });
 execSync('rm -rf cld3/.git', { cwd: root });
 execSync('mkdir -p build', { cwd: cld3Path });
 execSync('cmake -S . -B ./build', { cwd: cld3Path });


### PR DESCRIPTION
Fix the build of the library to be used with latest version of the Protobuf library (see https://github.com/google/cld3/pull/85 for more info)

The installation script use my fork of cld3 while Google accept (or not) the PR